### PR TITLE
BS-187 | Using drug codeable concept instead of medication reference in MedicationRequest

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhirExtension/export/impl/MedicationRequestExport.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/export/impl/MedicationRequestExport.java
@@ -3,21 +3,35 @@ package org.openmrs.module.fhirExtension.export.impl;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Medication;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.openmrs.Drug;
+import org.openmrs.DrugOrder;
+import org.openmrs.api.OrderService;
 import org.openmrs.module.fhir2.api.FhirMedicationRequestService;
+import org.openmrs.module.fhir2.api.translators.MedicationTranslator;
 import org.openmrs.module.fhirExtension.export.Exporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class MedicationRequestExport implements Exporter {
 	
-	private FhirMedicationRequestService fhirMedicationRequestService;
+	private final FhirMedicationRequestService fhirMedicationRequestService;
+	
+	private final MedicationTranslator medicationTranslator;
+	
+	private final OrderService orderService;
 	
 	@Autowired
-	public MedicationRequestExport(FhirMedicationRequestService fhirMedicationRequestService) {
+	public MedicationRequestExport(FhirMedicationRequestService fhirMedicationRequestService,
+	    MedicationTranslator medicationTranslator, OrderService orderService) {
 		this.fhirMedicationRequestService = fhirMedicationRequestService;
+		this.medicationTranslator = medicationTranslator;
+		this.orderService = orderService;
 	}
 	
 	@Override
@@ -25,7 +39,16 @@ public class MedicationRequestExport implements Exporter {
 		DateRangeParam lastUpdated = getLastUpdated(startDate, endDate);
 		IBundleProvider iBundleProvider = fhirMedicationRequestService.searchForMedicationRequests(null, null, null, null,
 		    null, null, null, null, lastUpdated, null, null);
-		return iBundleProvider.getAllResources();
+		List<IBaseResource> medicationRequests = iBundleProvider.getAllResources().stream().map(this::addMedicationInfo).collect(Collectors.toList());
+		return medicationRequests;
 	}
 	
+	private MedicationRequest addMedicationInfo(IBaseResource iBaseResource) {
+		MedicationRequest medicationRequest = (MedicationRequest) iBaseResource;
+		String orderUuid = medicationRequest.getId();
+		Drug drug = ((DrugOrder) orderService.getOrderByUuid(orderUuid)).getDrug();
+		Medication medicationFhirResource = medicationTranslator.toFhirResource(drug);
+		medicationRequest.setMedication(medicationFhirResource.getCode());
+		return medicationRequest;
+	}
 }

--- a/api/src/test/java/org/openmrs/module/fhirExtension/export/impl/MedicationRequestExportTest.java
+++ b/api/src/test/java/org/openmrs/module/fhirExtension/export/impl/MedicationRequestExportTest.java
@@ -3,6 +3,7 @@ package org.openmrs.module.fhirExtension.export.impl;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Medication;
 import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.Test;
@@ -10,7 +11,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.DrugOrder;
+import org.openmrs.api.OrderService;
 import org.openmrs.module.fhir2.api.FhirMedicationRequestService;
+import org.openmrs.module.fhir2.api.translators.MedicationTranslator;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +23,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,11 +32,19 @@ public class MedicationRequestExportTest {
 	@Mock
 	private FhirMedicationRequestService fhirMedicationRequestService;
 	
+	@Mock
+	private MedicationTranslator medicationTranslator;
+	
+	@Mock
+	private OrderService orderService;
+	
 	@InjectMocks
 	private MedicationRequestExport medicationRequestExport;
 	
 	@Test
 	public void shouldExportMedicationRequest_whenValidDateRangeProvided() {
+		when(orderService.getOrderByUuid(anyString())).thenReturn(new DrugOrder());
+		when(medicationTranslator.toFhirResource(any())).thenReturn(new Medication());
 		when(
 		    fhirMedicationRequestService.searchForMedicationRequests(any(), any(), any(), any(), any(), any(), any(), any(),
 		        any(), any(), any())).thenReturn(getMockMedicationRequestBundle());


### PR DESCRIPTION
JIRA : https://bahmni.atlassian.net/browse/BS-187

Summary
----------
- Updating `medicationReference` with `medicationCodeableConcept` in FHIR [MedicationRequest](http://hl7.org/fhir/R4/medicationrequest.html).