### PR TITLE
BAH-4008 | Add default value for anonymise config path

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -118,7 +118,7 @@
 
 	<globalProperty>
 		<property>fhir.export.anonymise.config.path</property>
-		<defaultValue></defaultValue>
+		<defaultValue>/openmrs/data/fhir-export-anonymise-config.json</defaultValue>
 		<description>Path of the config file that controls the anonymisation mechanism during bulk-export of patient data.</description>
 	</globalProperty>
 </module>


### PR DESCRIPTION
This PR adds a default value for `fhir.export.anonymise.config.path` global property.