### PR TITLE
BAH-4031 | Add. Configuration to set daemon as creator for system generated tasks

### DIFF
--- a/omod/src/main/java/org/openmrs/module/fhirExtension/web/contract/TaskRequest.java
+++ b/omod/src/main/java/org/openmrs/module/fhirExtension/web/contract/TaskRequest.java
@@ -32,4 +32,6 @@ public class TaskRequest {
 	
 	private String comment;
 	
+	private Boolean isSystemGeneratedTask = false;
+	
 }

--- a/omod/src/main/java/org/openmrs/module/fhirExtension/web/mapper/TaskMapper.java
+++ b/omod/src/main/java/org/openmrs/module/fhirExtension/web/mapper/TaskMapper.java
@@ -8,6 +8,7 @@ import org.openmrs.api.LocationService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
 import org.openmrs.module.fhir2.model.FhirReference;
 import org.openmrs.module.fhir2.model.FhirTask;
 import org.openmrs.module.fhirExtension.model.FhirTaskRequestedPeriod;
@@ -74,6 +75,10 @@ public class TaskMapper {
 			fhirTaskRequestedPeriod.setRequestedStartTime(taskRequest.getRequestedStartTime());
 			fhirTaskRequestedPeriod.setRequestedEndTime(taskRequest.getRequestedEndTime());
 			task.setFhirTaskRequestedPeriod(fhirTaskRequestedPeriod);
+		}
+		
+		if (taskRequest.getIsSystemGeneratedTask()) {
+			fhirTask.setCreator(Context.getUserService().getUserByUuid(Daemon.getDaemonUserUuid()));
 		}
 		task.setFhirTask(fhirTask);
 		return task;


### PR DESCRIPTION
This PR adds configuration based on which the tasks creator will be set as `daemon` for system generated tasks