### PR TITLE
BAH-4062 | Add Privilege Checks for Task Resource

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskDaoImpl.java
@@ -23,10 +23,13 @@ import java.util.List;
 @Repository
 public class TaskDaoImpl implements TaskDao {
 	
-	@Autowired
 	private SessionFactory sessionFactory;
 	
 	private Log log = LogFactory.getLog(this.getClass());
+	
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
 	
 	@Override
 	public List<Task> getTasksByVisitFilteredByTimeFrame(Visit visit, Date startTime, Date endTime) {
@@ -99,11 +102,11 @@ public class TaskDaoImpl implements TaskDao {
 			CriteriaQuery<Task> criteriaQuery = criteriaBuilder.createQuery(Task.class);
 			Root<FhirTaskRequestedPeriod> fhirTaskRequestedPeriod = criteriaQuery.from(FhirTaskRequestedPeriod.class);
 			Join<FhirTask, FhirTaskRequestedPeriod> fhirTaskJoin = fhirTaskRequestedPeriod.join("task");
-			
+
 			criteriaQuery.select(criteriaBuilder.construct(Task.class, fhirTaskJoin, fhirTaskRequestedPeriod)).where(
 			    fhirTaskJoin.get("uuid").in(listOfUuids));
 			TypedQuery<Task> query = sessionFactory.getCurrentSession().createQuery(criteriaQuery);
-			
+
 			return query.getResultList();
 		}
 		catch (Exception e) {

--- a/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskRequestedPeriodDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskRequestedPeriodDaoImpl.java
@@ -12,8 +12,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class TaskRequestedPeriodDaoImpl implements TaskRequestedPeriodDao {
 	
-	@Autowired
 	private SessionFactory sessionFactory;
+	
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
 	
 	@Override
 	public FhirTaskRequestedPeriod getTaskRequestedPeriodByTaskId(Integer taskId) {

--- a/api/src/main/java/org/openmrs/module/fhirExtension/service/TaskService.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/service/TaskService.java
@@ -1,27 +1,32 @@
 package org.openmrs.module.fhirExtension.service;
 
-import org.openmrs.module.fhir2.model.FhirTask;
+import org.openmrs.annotation.Authorized;
 import org.openmrs.module.fhirExtension.model.Task;
 import org.openmrs.module.fhirExtension.model.TaskSearchRequest;
-import org.springframework.stereotype.Component;
+import org.openmrs.module.fhirExtension.utils.PrivilegeConstants;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
 
-@Component
 @Transactional
 public interface TaskService {
 	
+	@Authorized({ PrivilegeConstants.ADD_TASKS, PrivilegeConstants.EDIT_TASKS })
 	Task saveTask(Task task);
 	
+	@Authorized({ PrivilegeConstants.ADD_TASKS, PrivilegeConstants.EDIT_TASKS })
 	List<Task> saveTask(List<Task> tasks);
 	
+	@Authorized({ PrivilegeConstants.GET_TASKS })
 	List<Task> getTasksByVisitFilteredByTimeFrame(String visitUuid, Date startTime, Date endTime);
 	
+	@Authorized({ PrivilegeConstants.GET_TASKS })
 	List<Task> getTasksByPatientUuidsByTimeFrame(List<String> patientUuids, Date startTime, Date endTime);
 	
+	@Authorized({ PrivilegeConstants.GET_TASKS })
 	List<Task> getTasksByUuids(List<String> listOdUuids);
 	
+	@Authorized({ PrivilegeConstants.GET_TASKS })
 	List<Task> searchTasks(TaskSearchRequest taskSearchRequest);
 }

--- a/api/src/main/java/org/openmrs/module/fhirExtension/service/impl/TaskServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/service/impl/TaskServiceImpl.java
@@ -9,8 +9,6 @@ import org.openmrs.module.fhirExtension.model.FhirTaskRequestedPeriod;
 import org.openmrs.module.fhirExtension.model.Task;
 import org.openmrs.module.fhirExtension.model.TaskSearchRequest;
 import org.openmrs.module.fhirExtension.service.TaskService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
@@ -18,19 +16,14 @@ import java.util.List;
 import java.util.ArrayList;
 
 @Transactional
-@Component
 public class TaskServiceImpl implements TaskService {
 	
-	@Autowired
 	private FhirTaskDao fhirTaskDao;
 	
-	@Autowired
 	private VisitService visitService;
 	
-	@Autowired
 	private TaskDao taskDao;
 	
-	@Autowired
 	private TaskRequestedPeriodDao taskRequestedPeriodDao;
 	
 	@Override
@@ -77,5 +70,21 @@ public class TaskServiceImpl implements TaskService {
 	@Override
 	public List<Task> searchTasks(TaskSearchRequest taskSearchRequest) {
 		return taskDao.searchTasks(taskSearchRequest);
+	}
+	
+	public void setVisitService(VisitService visitService) {
+		this.visitService = visitService;
+	}
+	
+	public void setFhirTaskDao(FhirTaskDao fhirTaskDao) {
+		this.fhirTaskDao = fhirTaskDao;
+	}
+	
+	public void setTaskDao(TaskDao taskDao) {
+		this.taskDao = taskDao;
+	}
+	
+	public void setTaskRequestedPeriodDao(TaskRequestedPeriodDao taskRequestedPeriodDao) {
+		this.taskRequestedPeriodDao = taskRequestedPeriodDao;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/fhirExtension/utils/PrivilegeConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/utils/PrivilegeConstants.java
@@ -1,0 +1,13 @@
+package org.openmrs.module.fhirExtension.utils;
+
+public class PrivilegeConstants {
+	
+	private PrivilegeConstants() {
+	}
+	
+	public static final String GET_TASKS = "Get Tasks";
+	
+	public static final String EDIT_TASKS = "Edit Tasks";
+	
+	public static final String ADD_TASKS = "Add Tasks";
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -97,6 +97,18 @@
 		<name>Export Non Anonymised Patient Data</name>
 		<description>Ability to bulk-export patient data that has NOT been anonymised, in FHIR JSON format</description>
 	</privilege>
+	<privilege>
+		<name>Get Tasks</name>
+		<description>Ability to get FHIR Tasks</description>
+	</privilege>
+	<privilege>
+		<name>Add Tasks</name>
+		<description>Ability to create FHIR Tasks</description>
+	</privilege>
+	<privilege>
+		<name>Edit Tasks</name>
+		<description>Ability to edit FHIR Tasks</description>
+	</privilege>
 
 	<globalProperty>
 		<property>labEntry.visitType</property>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <module configVersion="1.2">
-	
+
 	<!-- Base Module Properties -->
 	<id>${project.parent.artifactId}</id>
 	<name>${project.parent.name}</name>
@@ -13,35 +13,35 @@
 	</description>
 
 	<activator>org.openmrs.module.fhirExtension.FhirExtensionModuleActivator</activator>
-	
+
 	<!-- <updateURL>https://modules.openmrs.org/modules/download/@MODULE_ID@/update.rdf</updateURL> -->
 	<!-- /Base Module Properties -->
-	
+
 	<require_version>${openmrsPlatformVersion}</require_version>
-	
+
 <!--	 Extensions -->
 <!--	<extension>-->
 <!--		<point>org.openmrs.admin.list</point>-->
 <!--		<class>${MODULE_PACKAGE}.extension.html.AdminList</class>-->
 <!--	</extension>-->
-	
-	
+
+
 	<!-- AOP
 	<advice>
 		<point>org.openmrs.api.FormService</point>
 		<class>@MODULE_PACKAGE@.advice.DuplicateFormAdvisor</class>
 	</advice>
 	 /AOP -->
-	
-	
-	<!-- Required Privileges 
+
+
+	<!-- Required Privileges
 	<privilege>
 		<name>Form Entry</name>
 		<description>Allows user to access Form Entry pages/functions</description>
 	</privilege>
 	 /Required Privileges -->
 
-	<!-- Required Global Properties 
+	<!-- Required Global Properties
 	<globalProperty>
 		<property>@MODULE_ID@.someProperty</property>
 		<defaultValue></defaultValue>
@@ -52,17 +52,17 @@
 		</description>
 	</globalProperty>
 	/Required Global Properties -->
-	
+
 	<!-- Servlets -->
-	<!-- Accessed through the url /pageContext()/moduleServlet/<moduleId>/<servlet-name> 
+	<!-- Accessed through the url /pageContext()/moduleServlet/<moduleId>/<servlet-name>
 	<servlet>
 		<servlet-name>formDownload</servlet-name>
 		<servlet-class>@MODULE_PACKAGE@.web.FormDownloadServlet</servlet-class>
 	</servlet>
 	-->
 	<!-- /Servlets -->
-	
-	
+
+
 	<!-- Internationalization -->
 	<!-- All message codes should start with @MODULE_ID@.* -->
 	<aware_of_modules>

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -27,6 +27,48 @@
 	<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping"/>
 
 	<context:component-scan base-package="org.openmrs.module.fhirExtension" />
+	<bean id="taskServiceTarget" class="org.openmrs.module.fhirExtension.service.impl.TaskServiceImpl">
+		<property name="visitService" ref="visitService"/>
+		<property name="fhirTaskDao">
+			<bean class="org.openmrs.module.fhir2.api.dao.impl.FhirTaskDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="sessionFactory" />
+				</property>
+			</bean>
+		</property>
+		<property name="taskDao">
+			<bean class="org.openmrs.module.fhirExtension.dao.impl.TaskDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="sessionFactory" />
+				</property>
+			</bean>
+		</property>
+		<property name="taskRequestedPeriodDao">
+			<bean class="org.openmrs.module.fhirExtension.dao.impl.TaskRequestedPeriodDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="sessionFactory" />
+				</property>
+			</bean>
+		</property>
+	</bean>
+	<bean id="taskService"
+		  class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager" ref="transactionManager" />
+		<property name="target" ref="taskServiceTarget"/>
+		<property name="preInterceptors" ref="serviceInterceptors" />
+		<property name="transactionAttributeSource">
+			<bean
+					class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource" />
+		</property>
+	</bean>
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list>
+				<value>org.openmrs.module.fhirExtension.service.TaskService</value>
+				<ref bean="taskService"/>
+			</list>
+		</property>
+	</bean>
 
 
 </beans>

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -29,13 +29,7 @@
 	<context:component-scan base-package="org.openmrs.module.fhirExtension" />
 	<bean id="taskServiceTarget" class="org.openmrs.module.fhirExtension.service.impl.TaskServiceImpl">
 		<property name="visitService" ref="visitService"/>
-		<property name="fhirTaskDao">
-			<bean class="org.openmrs.module.fhir2.api.dao.impl.FhirTaskDaoImpl">
-				<property name="sessionFactory">
-					<ref bean="sessionFactory" />
-				</property>
-			</bean>
-		</property>
+		<property name="fhirTaskDao" ref="fhirTaskDaoImpl"/>
 		<property name="taskDao">
 			<bean class="org.openmrs.module.fhirExtension.dao.impl.TaskDaoImpl">
 				<property name="sessionFactory">

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
 		<repository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Public Repository</name>
-			<url>https://openmrs.jfrog.io/artifactory/public</url>
+			<url>https://mavenrepo.openmrs.org/public</url>
 		</repository>
 		<repository>
 			<id>openmrs-snapshots</id>
 			<name>OpenMRS Snapshot Repository</name>
-			<url>https://openmrs.jfrog.io/artifactory/snapshots</url>
+			<url>https://mavenrepo.openmrs.org/snapshots</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -85,7 +85,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>https://openmrs.jfrog.io/artifactory/nexus/content/repositories/public</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>https://openmrs.jfrog.io/artifactory/public</url>
+			<url>https://openmrs.jfrog.io/artifactory/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
 		<repository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Public Repository</name>
-			<url>https://mavenrepo.openmrs.org/public</url>
+			<url>https://openmrs.jfrog.io/artifactory/public</url>
 		</repository>
 		<repository>
 			<id>openmrs-snapshots</id>
 			<name>OpenMRS Snapshot Repository</name>
-			<url>https://mavenrepo.openmrs.org/snapshots</url>
+			<url>https://openmrs.jfrog.io/artifactory/snapshots</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -85,7 +85,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+			<url>https://openmrs.jfrog.io/artifactory/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>https://openmrs.jfrog.io/artifactory/nexus/content/repositories/public</url>
+			<url>https://openmrs.jfrog.io/artifactory/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
This PR adds privilege checks for Task Resource service methods.
In order for the interceptor to execute, service implementation and bean creation is defined through moduleApplicationContext instead of using `@Autowired` and `@Component` annotations.

JIRA: https://bahmni.atlassian.net/browse/BAH-4062