### PR TITLE
BAH-4106 | Fix. Remove @Repository annotation and create beans through xml

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-@Repository
 public class TaskDaoImpl implements TaskDao {
 	
 	private SessionFactory sessionFactory;

--- a/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskRequestedPeriodDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/dao/impl/TaskRequestedPeriodDaoImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 
 // TODO: This Dao is to be removed after support openmrs R5
 
-@Repository
 public class TaskRequestedPeriodDaoImpl implements TaskRequestedPeriodDao {
 	
 	private SessionFactory sessionFactory;

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -27,23 +27,21 @@
 	<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping"/>
 
 	<context:component-scan base-package="org.openmrs.module.fhirExtension" />
+	<bean id="taskDao" class="org.openmrs.module.fhirExtension.dao.impl.TaskDaoImpl">
+		<property name="sessionFactory">
+			<ref bean="sessionFactory" />
+		</property>
+	</bean>
+	<bean id="taskRequestedPeriodDao" class="org.openmrs.module.fhirExtension.dao.impl.TaskRequestedPeriodDaoImpl">
+		<property name="sessionFactory">
+			<ref bean="sessionFactory" />
+		</property>
+	</bean>
 	<bean id="taskServiceTarget" class="org.openmrs.module.fhirExtension.service.impl.TaskServiceImpl">
 		<property name="visitService" ref="visitService"/>
 		<property name="fhirTaskDao" ref="fhirTaskDaoImpl"/>
-		<property name="taskDao">
-			<bean class="org.openmrs.module.fhirExtension.dao.impl.TaskDaoImpl">
-				<property name="sessionFactory">
-					<ref bean="sessionFactory" />
-				</property>
-			</bean>
-		</property>
-		<property name="taskRequestedPeriodDao">
-			<bean class="org.openmrs.module.fhirExtension.dao.impl.TaskRequestedPeriodDaoImpl">
-				<property name="sessionFactory">
-					<ref bean="sessionFactory" />
-				</property>
-			</bean>
-		</property>
+		<property name="taskDao" ref="taskDao"/>
+		<property name="taskRequestedPeriodDao" ref="taskRequestedPeriodDao"/>
 	</bean>
 	<bean id="taskService"
 		  class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">


### PR DESCRIPTION
This PR refactors bean initialisation for taskDao and taskRequestedPeriodDao to be created from xml rather than through `@Repository` annotation.