### PR TITLE
BAH-4180 | Refactor. Migrate Sonatype Central Portal publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,24 +60,13 @@
 		<repository>
 			<id>sonatype-nexus-snapshots</id>
 			<name>Sonatype Nexus Snapshots</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>interval:10080</updatePolicy>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>sonatype-nexus-releases</id>
-			<name>Sonatype Nexus Snapshots</name>
-			<url>https://oss.sonatype.org/content/repositories/releases</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
 			</snapshots>
 		</repository>
 	</repositories>
@@ -262,39 +251,20 @@
 						</excludes>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.5.1</version>
-					<extensions>true</extensions>
-					<executions>
-						<execution>
-							<id>default-deploy</id>
-							<phase>deploy</phase>
-							<goals>
-								<goal>deploy</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<serverId>nexus-sonatype</serverId>
-						<nexusUrl>https://oss.sonatype.org</nexusUrl>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>0.7.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<publishingServerId>nexus-sonatype</publishingServerId>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
-
-	<distributionManagement>
-		<snapshotRepository>
-			<id>nexus-sonatype</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>nexus-sonatype</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-		</repository>
-	</distributionManagement>
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
- Updated Maven configuration to use Sonatype Central Portal for publishing artifacts
- Removed obsolete Sonatype OSS Nexus repository configurations
- Added central-publishing-maven-plugin to support the new publishing workflow

JIRA: https://bahmni.atlassian.net/browse/BAH-4180