### PR TITLE
BAH-4180 | Fix. Override distribution management URL for SNAPSHOT builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,13 @@
 		</plugins>
 	</build>
 
+	<distributionManagement>
+		<snapshotRepository>
+			<id>nexus-sonatype</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
+
 	<profiles>
 		<profile>
 			<id>release-sign-artifacts</id>


### PR DESCRIPTION
This PR overrides the distributionManagement configuration coming from `maven-parent-openmrs-module` to point to Central Sonatype Portal URL. 

Note: The release URL does need to be overriden as the plugin itslef defaults to Central Sonatype URL and is not overriden by disributionManagement configuration.