### PR TITLE
FM2-658 | Upgrade fhir2 module dependency version

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhirExtension/export/impl/PatientExport.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/export/impl/PatientExport.java
@@ -30,7 +30,7 @@ public class PatientExport implements Exporter {
 	public List<IBaseResource> export(String startDate, String endDate) {
 		DateRangeParam lastUpdated = getLastUpdated(startDate, endDate);
 		PatientSearchParams patientSearchParams = new PatientSearchParams(null, null, null, null, null, null, null, null,
-		        null, null, null, null, null, lastUpdated, null, null);
+		        null, null, null, null, null, null, lastUpdated, null, null);
 		IBundleProvider iBundleProvider = fhirPatientService.searchForPatients(patientSearchParams);
 		return iBundleProvider.getAllResources();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
 			<openmrsPlatformVersion>2.5.12</openmrsPlatformVersion>
-			<openmrs.fhir2.version>2.1.0</openmrs.fhir2.version>
+			<openmrs.fhir2.version>2.4.0</openmrs.fhir2.version>
 			<web.services.version>2.44.0</web.services.version>
 			<junitVersion>4.13.1</junitVersion>
 			<lombokVersion>1.18.16</lombokVersion>


### PR DESCRIPTION
This PR upgrades the version of fhir2 module to match the version being shipped in Bahmni Distro.
The version has been upgraded in distro as part of this [PR](https://github.com/Bahmni/openmrs-distro-bahmni/pull/223).