### PR TITLE
BS-262 | Fix. Remove concrete dependency on ExportAsyncService in ExportController

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhirExtension/service/ExportAsyncService.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/service/ExportAsyncService.java
@@ -1,88 +1,9 @@
 package org.openmrs.module.fhirExtension.service;
 
-import lombok.extern.log4j.Log4j2;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.openmrs.api.ConceptService;
-import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
-import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
 import org.openmrs.module.fhir2.model.FhirTask;
-import org.openmrs.module.fhirExtension.export.Exporter;
-import org.openmrs.module.fhirExtension.export.anonymise.handler.AnonymiseHandler;
-import org.openmrs.module.fhirExtension.export.anonymise.impl.CorrelationCache;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
-
-@Log4j2
-@Component
-@Transactional
-public class ExportAsyncService {
+public interface ExportAsyncService {
 	
-	private FhirTaskDao fhirTaskDao;
-	
-	private ConceptService conceptService;
-	
-	private FileExportService fileExportService;
-	
-	private AnonymiseHandler anonymiseHandler;
-	
-	private CorrelationCache correlationCache;
-	
-	@Autowired
-	public ExportAsyncService(FhirTaskDao fhirTaskDao, ConceptService conceptService, FileExportService fileExportService,
-	    AnonymiseHandler anonymiseHandler, CorrelationCache correlationCache) {
-		this.fhirTaskDao = fhirTaskDao;
-		this.conceptService = conceptService;
-		this.fileExportService = fileExportService;
-		this.anonymiseHandler = anonymiseHandler;
-		this.correlationCache = correlationCache;
-	}
-	
-	@Async("export-fhir-data-threadPoolTaskExecutor")
-	public void export(FhirTask fhirTask, String startDate, String endDate, UserContext userContext, boolean isAnonymise) {
-		FhirTask.TaskStatus taskStatus = null;
-		
-		try {
-			Context.openSession();
-			Context.setUserContext(userContext);
-			List<Exporter> fhirExporters = Context.getRegisteredComponents(Exporter.class);
-			initialize(fhirTask, isAnonymise);
-			
-			for (Exporter fhirExporter : fhirExporters) {
-				List<IBaseResource> fhirResources = fhirExporter.export(startDate, endDate);
-				anonymise(fhirResources, fhirExporter.getResourceType(), isAnonymise);
-				fileExportService.createAndWriteToFile(fhirResources, fhirTask.getUuid());
-			}
-			
-			fileExportService.createZipWithExportedNdjsonFiles(fhirTask.getUuid());
-			fileExportService.deleteDirectory(fhirTask.getUuid());
-		}
-		catch (Exception exception) {
-			taskStatus = FhirTask.TaskStatus.REJECTED;
-			log.error("Exception occurred while exporting data in FHIR format ", exception);
-		}
-		finally {
-			if (taskStatus == null) {
-				taskStatus = FhirTask.TaskStatus.COMPLETED;
-			}
-			fhirTask.setStatus(taskStatus);
-			fhirTaskDao.createOrUpdate(fhirTask);
-		}
-	}
-	
-	private void initialize(FhirTask fhirTask, boolean isAnonymise) {
-		fileExportService.createDirectory(fhirTask.getUuid());
-		correlationCache.reset();
-		anonymiseHandler.loadAnonymiserConfig(isAnonymise);
-	}
-	
-	private void anonymise(List<IBaseResource> iBaseResources, String resourceType, boolean isAnonymise) {
-        if (isAnonymise) {
-            iBaseResources.forEach(iBaseResource -> anonymiseHandler.anonymise(iBaseResource, resourceType));
-        }
-    }
+	void export(FhirTask fhirTask, String startDate, String endDate, UserContext userContext, boolean isAnonymise);
 }

--- a/api/src/main/java/org/openmrs/module/fhirExtension/service/impl/ExportAsyncServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhirExtension/service/impl/ExportAsyncServiceImpl.java
@@ -1,0 +1,91 @@
+package org.openmrs.module.fhirExtension.service.impl;
+
+import lombok.extern.log4j.Log4j2;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
+import org.openmrs.module.fhir2.model.FhirTask;
+import org.openmrs.module.fhirExtension.export.Exporter;
+import org.openmrs.module.fhirExtension.export.anonymise.handler.AnonymiseHandler;
+import org.openmrs.module.fhirExtension.export.anonymise.impl.CorrelationCache;
+import org.openmrs.module.fhirExtension.service.ExportAsyncService;
+import org.openmrs.module.fhirExtension.service.FileExportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Log4j2
+@Component
+@Transactional
+public class ExportAsyncServiceImpl implements ExportAsyncService {
+	
+	private FhirTaskDao fhirTaskDao;
+	
+	private ConceptService conceptService;
+	
+	private FileExportService fileExportService;
+	
+	private AnonymiseHandler anonymiseHandler;
+	
+	private CorrelationCache correlationCache;
+	
+	@Autowired
+	public ExportAsyncServiceImpl(FhirTaskDao fhirTaskDao, ConceptService conceptService,
+	    FileExportService fileExportService, AnonymiseHandler anonymiseHandler, CorrelationCache correlationCache) {
+		this.fhirTaskDao = fhirTaskDao;
+		this.conceptService = conceptService;
+		this.fileExportService = fileExportService;
+		this.anonymiseHandler = anonymiseHandler;
+		this.correlationCache = correlationCache;
+	}
+	
+	@Override
+	@Async("export-fhir-data-threadPoolTaskExecutor")
+	public void export(FhirTask fhirTask, String startDate, String endDate, UserContext userContext, boolean isAnonymise) {
+		FhirTask.TaskStatus taskStatus = null;
+		
+		try {
+			Context.openSession();
+			Context.setUserContext(userContext);
+			List<Exporter> fhirExporters = Context.getRegisteredComponents(Exporter.class);
+			initialize(fhirTask, isAnonymise);
+			
+			for (Exporter fhirExporter : fhirExporters) {
+				List<IBaseResource> fhirResources = fhirExporter.export(startDate, endDate);
+				anonymise(fhirResources, fhirExporter.getResourceType(), isAnonymise);
+				fileExportService.createAndWriteToFile(fhirResources, fhirTask.getUuid());
+			}
+			
+			fileExportService.createZipWithExportedNdjsonFiles(fhirTask.getUuid());
+			fileExportService.deleteDirectory(fhirTask.getUuid());
+		}
+		catch (Exception exception) {
+			taskStatus = FhirTask.TaskStatus.REJECTED;
+			log.error("Exception occurred while exporting data in FHIR format ", exception);
+		}
+		finally {
+			if (taskStatus == null) {
+				taskStatus = FhirTask.TaskStatus.COMPLETED;
+			}
+			fhirTask.setStatus(taskStatus);
+			fhirTaskDao.createOrUpdate(fhirTask);
+		}
+	}
+	
+	private void initialize(FhirTask fhirTask, boolean isAnonymise) {
+		fileExportService.createDirectory(fhirTask.getUuid());
+		correlationCache.reset();
+		anonymiseHandler.loadAnonymiserConfig(isAnonymise);
+	}
+	
+	private void anonymise(List<IBaseResource> iBaseResources, String resourceType, boolean isAnonymise) {
+        if (isAnonymise) {
+            iBaseResources.forEach(iBaseResource -> anonymiseHandler.anonymise(iBaseResource, resourceType));
+        }
+    }
+}

--- a/api/src/test/java/org/openmrs/module/fhirExtension/service/ExportAsyncServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/fhirExtension/service/ExportAsyncServiceTest.java
@@ -24,6 +24,7 @@ import org.openmrs.module.fhirExtension.export.Exporter;
 import org.openmrs.module.fhirExtension.export.anonymise.handler.AnonymiseHandler;
 import org.openmrs.module.fhirExtension.export.anonymise.impl.CorrelationCache;
 import org.openmrs.module.fhirExtension.export.impl.ConditionExport;
+import org.openmrs.module.fhirExtension.service.impl.ExportAsyncServiceImpl;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -62,7 +63,7 @@ public class ExportAsyncServiceTest {
 	private CorrelationCache correlationCache;
 	
 	@InjectMocks
-	private ExportAsyncService exportAsyncService;
+	private ExportAsyncServiceImpl exportAsyncServiceImpl;
 	
 	@Before
 	public void setUp() {
@@ -77,7 +78,7 @@ public class ExportAsyncServiceTest {
 	public void shouldExportPatientDataAndUpdateFhirTaskStatusToCompleted_whenValidDateRangeProvided() {
 		FhirTask fhirTask = mockFhirTask();
 		when(conceptService.getConceptByName(any())).thenReturn(new Concept());
-		exportAsyncService.export(fhirTask, "2023-01-01", "2023-12-31", Context.getUserContext(), false);
+		exportAsyncServiceImpl.export(fhirTask, "2023-01-01", "2023-12-31", Context.getUserContext(), false);
 		
 		assertEquals(FhirTask.TaskStatus.COMPLETED, fhirTask.getStatus());
 		assertEquals(4, fhirTask.getInput().size());
@@ -92,7 +93,7 @@ public class ExportAsyncServiceTest {
 
 		FhirTask fhirTask = mockFhirTask();
 
-		exportAsyncService.export(fhirTask, "2023-AB-CD", "2023-12-31", Context.getUserContext(), false);
+		exportAsyncServiceImpl.export(fhirTask, "2023-AB-CD", "2023-12-31", Context.getUserContext(), false);
 
 		assertEquals(FhirTask.TaskStatus.REJECTED, fhirTask.getStatus());
 		verify(fhirTaskDao, times(1)).createOrUpdate(any(FhirTask.class));
@@ -108,7 +109,7 @@ public class ExportAsyncServiceTest {
 
 		FhirTask fhirTask = mockFhirTask();
 
-		exportAsyncService.export(fhirTask, "2023-01-01", "2023-12-31", Context.getUserContext(), true);
+		exportAsyncServiceImpl.export(fhirTask, "2023-01-01", "2023-12-31", Context.getUserContext(), true);
 
 		assertEquals(FhirTask.TaskStatus.COMPLETED, fhirTask.getStatus());
 		verify(anonymiseHandler, times(1)).anonymise(any(IBaseResource.class), eq("condition"));

--- a/omod/src/test/java/org/openmrs/module/fhirExtension/web/ExportControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhirExtension/web/ExportControllerTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.ContextAuthenticationException;
 import org.openmrs.module.fhir2.model.FhirTask;
-import org.openmrs.module.fhirExtension.service.ExportAsyncService;
+import org.openmrs.module.fhirExtension.service.impl.ExportAsyncServiceImpl;
 import org.openmrs.module.fhirExtension.service.ExportTask;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.powermock.api.mockito.PowerMockito;
@@ -44,7 +44,7 @@ public class ExportControllerTest {
 	private ExportTask exportTask;
 	
 	@Mock
-	private ExportAsyncService exportAsyncService;
+	private ExportAsyncServiceImpl exportAsyncServiceImpl;
 	
 	@InjectMocks
 	private ExportController exportController;
@@ -60,7 +60,7 @@ public class ExportControllerTest {
 	
 	@Test
 	public void shouldGetFhirTaskUrl_whenFhirExportCalled() {
-		doNothing().when(exportAsyncService).export(any(), any(), any(), any(), anyBoolean());
+		doNothing().when(exportAsyncServiceImpl).export(any(), any(), any(), any(), anyBoolean());
 		when(exportTask.getInitialTaskResponse(any(), any(), any(), anyBoolean())).thenReturn(mockFhirTask());
 		when(exportTask.validateParams("2023-05-01", "2023-05-31")).thenReturn(null);
 		ResponseEntity<SimpleObject> responseEntity = exportController.export("2023-05-01", "2023-05-31", true);
@@ -73,7 +73,7 @@ public class ExportControllerTest {
 	
 	@Test
 	public void shouldGetBadRequest_whenFhirExportCalledWithInvalidDateFormat() {
-		doNothing().when(exportAsyncService).export(any(), any(), any(), any(), anyBoolean());
+		doNothing().when(exportAsyncServiceImpl).export(any(), any(), any(), any(), anyBoolean());
 		when(exportTask.getInitialTaskResponse(any(), any(), any(), anyBoolean())).thenReturn(mockFhirTask());
 		when(exportTask.validateParams("2023-05-AB", "2023-05-31")).thenReturn("Invalid Date Format [yyyy-mm-dd]");
 		ResponseEntity<SimpleObject> responseEntity = exportController.export("2023-05-AB", "2023-05-31", true);


### PR DESCRIPTION
This PR resolves the issue with OpenMRS service failing to start due to concrete dependency of ExportAsyncService on ExportController.